### PR TITLE
Toolkit to M, json unmarshal

### DIFF
--- a/m.go
+++ b/m.go
@@ -32,7 +32,7 @@ func ToM(v interface{}) (M, error) {
 	}
 
 	m := M{}
-	e = json.Unmarshal(bs, m)
+	e = json.Unmarshal(bs, &m)
 	if e != nil {
 		return m, fmt.Errorf("Unable to uncast to M from bytes: " + e.Error())
 	}


### PR DESCRIPTION
json unmarshal in toolkit.ToM, 
to unmarshal the second parameter should
be pointer format
