### PR TITLE
fix bug on `Value2Interface` method

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -184,7 +184,7 @@ func Value2Interface(vi reflect.Value) interface{} {
 	vik := vi.Type().String()
 	if strings.Contains(vik, "string") {
 		return vi.String()
-	} else if strings.Contains(vik, "int") {
+	} else if strings.Contains(vik, "int") && !strings.Contains(vik, "interface") {
 		return int(vi.Int())
 	} else if strings.Contains(vik, "float") {
 		return vi.Float()


### PR DESCRIPTION
`"int"` & `"interface"` contains same word, and it cause `strings.Contains(vik, "int")` will return `true` for those two datatypes.
