### PR TITLE
fix bug: panic on undefined `d`

### DIFF
--- a/m.go
+++ b/m.go
@@ -16,10 +16,10 @@ func (m M) Set(k string, v interface{}) M {
 
 func (m M) Get(k string, d ...interface{}) interface{} {
 	if get, b := m[k]; b {
-        if IsNilOrEmpty(get){
-            get=d[0]
-        }
-        return get
+		if IsNilOrEmpty(get) && len(d) > 0 {
+			get = d[0]
+		}
+		return get
 	} else {
 		if len(d) > 0 {
 			return d[0]


### PR DESCRIPTION
fix bug: if the result of Get is nil/empty (default value of respective data type), it'll call the `d[0]`. but if the `d` is undefined, it generate some errors
