### PR TITLE
Create new func `ToHttpHandler`, to convert `func(http.ResponseWriter, *http.Request)` to become `http.Handler` implementation

### DIFF
--- a/http.go
+++ b/http.go
@@ -174,3 +174,15 @@ func HttpGetCookieJar(url string, callType string,
 
 	return jar, errCall
 }
+
+type builder struct {
+	handler func(http.ResponseWriter, *http.Request)
+}
+
+func (b builder) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	b.handler(w, r)
+}
+
+func ToHttpHandler(handleFunc func(http.ResponseWriter, *http.Request)) http.Handler {
+	return builder{handler: handleFunc}
+}


### PR DESCRIPTION
Create new func `ToHttpHandler`, what this function can do is, convert closure with structure `func(http.ResponseWriter, *http.Request)` to be object which follow interface `http.Handler` requirement.

As we know, there are some difference between `mux.HandleFunc` and `mux.Handle`:
- `mux.HandleFunc` 2nd param must be filled by closure with structure `func(http.ResponseWriter, *http.Request)`
- `mux.Handle` 2nd param must be filled by object which meet interface `http.Handler` requirement

`http.Handler` interface has function called `ServeHTTP(http.ResponseWriter, *http.Request)` which must be implemented on the concrete object. And this `ToHttpHandler` will make us easily convert handler closure to `http.Handler`.
