### PR TITLE
add func `ExecuteBlockWithTimeout`

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"strings"
+	"time"
 )
 
 var gobs []string
@@ -298,4 +299,19 @@ func ExecFunc(fn interface{}, ins ...interface{}) (outs []reflect.Value, e error
 	}
 	outs = rvfn.Call(rvins)
 	return
+}
+
+func ExecuteBlockWithTimeout(callback func() interface{}, timeout time.Duration) (interface{}, bool) {
+	ch := make(chan interface{}, 1)
+
+	go func() {
+		ch <- callback()
+	}()
+
+	select {
+	case res := <-ch:
+		return res, true
+	case <-time.After(timeout * time.Second):
+		return nil, false
+	}
 }


### PR DESCRIPTION
This function is useful to handle some blocks of statement which taking too long time, by putting timeout on it.

So when the block execution time is exceeding the timeout duration, this function will return `false`

```go
package main

import "fmt"
import "github.com/eaciit/toolkit"
import "time"

const timeoutDuration = time.Duration(3)

func main() {
	successScenario()
	timeoutScenario()
}

func successScenario() {
	fmt.Println(">>> SCENARIO 1")
	res, status := toolkit.ExecuteBlockWithTimeout(func() interface{} {
		// do something
		return "this is the result"
	}, timeoutDuration)

	if status {
		fmt.Println("SUCCESS", res)
	} else {
		fmt.Println("TIMEOUT")
	}
}

func timeoutScenario() {
	fmt.Println(">>> SCENARIO 2")
	res, status := toolkit.ExecuteBlockWithTimeout(func() interface{} {
		time.Sleep(6 * time.Second) // sleep for 6 seconds
		return "this is the result"
	}, timeoutDuration)

	if status {
		fmt.Println("SUCCESS", res)
	} else {
		fmt.Println("TIMEOUT")
	}
}
```