### PR TITLE
small fixes & new funcs

### DIFF
--- a/generic.go
+++ b/generic.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"reflect"
 	"strings"
+	"time"
 )
 
 var gobs []string
@@ -298,4 +299,19 @@ func ExecFunc(fn interface{}, ins ...interface{}) (outs []reflect.Value, e error
 	}
 	outs = rvfn.Call(rvins)
 	return
+}
+
+func ExecuteBlockWithTimeout(callback func() interface{}, timeout time.Duration) (interface{}, bool) {
+	ch := make(chan interface{}, 1)
+
+	go func() {
+		ch <- callback()
+	}()
+
+	select {
+	case res := <-ch:
+		return res, true
+	case <-time.After(timeout * time.Second):
+		return nil, false
+	}
 }

--- a/generic.go
+++ b/generic.go
@@ -70,7 +70,7 @@ func IsNilOrEmpty(x interface{}) bool {
 		return false
 	} else if k == reflect.Bool {
 		return false
-	} else if strings.HasPrefix(k.String(), "int") || strings.Contains(k.String(), "float") {
+	} else if strings.HasPrefix(k.String(), "int") || strings.Contains(k.String(), "uint") || strings.Contains(k.String(), "float") {
 		iszero := x == reflect.Zero(reflect.TypeOf(x)).Interface()
 		if iszero {
 			return true


### PR DESCRIPTION
- fix error occured on checking data which type is `uint` on `IsNilOrEmpty`
- new func to execute block with timeout (blocking). example:

```go
result, isDone := ExecuteBlockWithTimeout(func () interface{} {
        return xlsx.OpenFile(path)
}, 5 * time.Second)

if isDone {
        fmt.Println("success", result)
} else {
        fmt.Println("timeout")
}

// if opening excel file take more than 5 second, then `isDone` will be false
// `result` is returned data from `xlsx.OpenFile()`

```