### PR TITLE
unit test for bytes.go and cast.go, and also small fix on cast.go

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 ._*
+cover.html
+cover.out

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+.PHONY: all test clean
+
+install:
+	go install
+
+test:
+	# clear && printf '\e[3J'
+	GOCACHE=off go test -cover -v ./
+	exit
+
+test+coverage:
+	# clear && printf '\e[3J'
+	GOCACHE=off go test -cover -coverprofile cover.out -v ./
+	go tool cover -html=cover.out -o cover.html
+	open cover.html
+	exit

--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
-# toolkit
+# Toolkit
 
 [![cover.run](https://cover.run/go/github.com/eaciit/toolkit.svg?style=flat&tag=golang-1.10)](https://cover.run/go?tag=golang-1.10&repo=github.com%2Feaciit%2Ftoolkit)
+
+General Purpose Utility Library for Golang
+
+### Test
+
+```bash
+$ make test
+```
+
+### Coverage Test
+
+```bash
+$ make test+coverage
+```

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# toolkit
+
+[![cover.run](https://cover.run/go/github.com/eaciit/toolkit.svg?style=flat&tag=golang-1.10)](https://cover.run/go?tag=golang-1.10&repo=github.com%2Feaciit%2Ftoolkit)

--- a/bytes_test.go
+++ b/bytes_test.go
@@ -1,0 +1,153 @@
+package toolkit
+
+import (
+	"fmt"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestToBytesJSON(t *testing.T) {
+	data := map[string]interface{}{
+		"Name":     "noval",
+		"Projects": []string{"dbox", "knot"},
+		"Age":      12,
+		"IsMale":   true,
+	}
+
+	bts := ToBytes(data, "json")
+	assert.Equal(t, `{"Age":12,"IsMale":true,"Name":"noval","Projects":["dbox","knot"]}`, string(bts))
+
+	// t.Logf("%s \n", string(bts))
+	// =====> {"Age":12,"IsMale":true,"Name":"noval","Projects":["dbox","knot"]}
+}
+
+func TestToBytesGOBAndFromBytesGOB(t *testing.T) {
+	data := map[string]interface{}{
+		"Name":     "noval",
+		"Projects": []string{"dbox", "knot"},
+		"Age":      12,
+		"IsMale":   true,
+	}
+
+	bts := ToBytes(data, "gob")
+
+	res := make(M)
+	err := FromBytes(bts, "gob", &res)
+	assert.NoError(t, err)
+
+	for key, value := range res {
+		switch key {
+		case "Name":
+			assert.True(t, data[key] == value.(string))
+		case "Projects":
+			assert.Len(t, value.([]string), len(data[key].([]string)))
+			assert.True(t, value.([]string)[0] == "dbox" || value.([]string)[0] == "knot")
+			assert.True(t, value.([]string)[1] == "dbox" || value.([]string)[1] == "knot")
+		case "Age":
+			assert.True(t, data[key] == value.(int))
+		case "IsMale":
+			assert.True(t, data[key] == value.(bool))
+		}
+	}
+
+	// t.Logf("%#v \n", res)
+	// =====> map[string]interface{}{"Name":"noval", "Projects":[]string{"dbox", "knot"}, "Age":12, "IsMale":true}
+}
+
+func TestToBytesWithEmptyEncoderId(t *testing.T) {
+	data := map[string]interface{}{
+		"Name":     "noval",
+		"Projects": []string{"dbox", "knot"},
+		"Age":      12,
+		"IsMale":   true,
+	}
+
+	bts := ToBytes(data, "")
+	assert.Equal(t, `{"Age":12,"IsMale":true,"Name":"noval","Projects":["dbox","knot"]}`, string(bts))
+
+	// t.Logf("%s \n", string(bts))
+	// =====> {"Age":12,"IsMale":true,"Name":"noval","Projects":["dbox","knot"]}
+}
+
+func TestToBytesWithInvalidEncoderId(t *testing.T) {
+	data := map[string]interface{}{
+		"Name":     "noval",
+		"Projects": []string{"dbox", "knot"},
+		"Age":      12,
+		"IsMale":   true,
+	}
+
+	bts := ToBytes(data, "lalala")
+	assert.Equal(t, "", string(bts))
+
+	// t.Logf("%s \n", string(bts))
+	// =====> {"Age":12,"IsMale":true,"Name":"noval","Projects":["dbox","knot"]}
+}
+
+func TestFromBytes(t *testing.T) {
+	jsonString := `{"Age":12,"IsMale":true,"Name":"noval","Projects":["dbox","knot"]}`
+	res := make(map[string]interface{})
+	err := FromBytes([]byte(jsonString), "json", &res)
+	assert.NoError(t, err)
+
+	for key, value := range res {
+		switch key {
+		case "Name":
+			assert.True(t, value == "noval")
+		case "Projects":
+			valueCasted := value.([]interface{})
+			assert.Len(t, valueCasted, 2)
+			assert.True(t, valueCasted[0] == "dbox" || valueCasted[0] == "knot")
+			assert.True(t, valueCasted[1] == "dbox" || valueCasted[1] == "knot")
+		case "Age":
+			assert.True(t, fmt.Sprintf("%s", value) == "12")
+		case "IsMale":
+			assert.True(t, value == true)
+		}
+	}
+
+	// t.Logf("%#v \n", res)
+	// =====> map[string]interface {}{"Age":"12", "IsMale":true, "Name":"noval", "Projects":[]interface {}{"dbox", "knot"}}
+}
+
+func TestFromBytesWithEmptyID(t *testing.T) {
+	jsonString := `{"Age":12,"IsMale":true,"Name":"noval","Projects":["dbox","knot"]}`
+	res := make(map[string]interface{})
+	err := FromBytes([]byte(jsonString), "", &res)
+	assert.NoError(t, err)
+
+	for key, value := range res {
+		switch key {
+		case "Name":
+			assert.True(t, value == "noval")
+		case "Projects":
+			valueCasted := value.([]interface{})
+			assert.Len(t, valueCasted, 2)
+			assert.True(t, valueCasted[0] == "dbox" || valueCasted[0] == "knot")
+			assert.True(t, valueCasted[1] == "dbox" || valueCasted[1] == "knot")
+		case "Age":
+			assert.True(t, fmt.Sprintf("%s", value) == "12")
+		case "IsMale":
+			assert.True(t, value == true)
+		}
+	}
+
+	// t.Logf("%#v \n", res)
+	// =====> map[string]interface {}{"Age":"12", "IsMale":true, "Name":"noval", "Projects":[]interface {}{"dbox", "knot"}}
+}
+
+func TestGetEncodeByte(t *testing.T) {
+	data := map[string]interface{}{
+		"Name":     "noval",
+		"Projects": []string{"dbox", "knot"},
+		"Age":      12,
+		"IsMale":   true,
+	}
+
+	res := make(map[string]interface{})
+	err := DecodeByte(GetEncodeByte(data), &res)
+	assert.NoError(t, err)
+
+	// t.Logf("%#v \n", res)
+	// ======> map[string]interface {}{"Projects":[]string{"dbox", "knot"}, "Age":12, "IsMale":true, "Name":"noval"}
+}

--- a/cast.go
+++ b/cast.go
@@ -36,11 +36,16 @@ func ToString(o interface{}) string {
 		} else {
 			return Sprintf("%s", o)
 		}
-	} else if k == reflect.Int || k == reflect.Int8 ||
-		k == reflect.Int16 || k == reflect.Int32 || k == reflect.Int64 {
+	} else if k == reflect.Int || k == reflect.Int8 || k == reflect.Int16 || k == reflect.Int32 || k == reflect.Int64 {
+		return fmt.Sprintf("%d", o)
+	} else if k == reflect.Uint || k == reflect.Uint8 || k == reflect.Uint16 || k == reflect.Uint32 || k == reflect.Uint64 {
 		return fmt.Sprintf("%d", o)
 	} else if k == reflect.Float32 || k == reflect.Float64 {
 		return fmt.Sprintf("%f", o)
+	} else if k == reflect.Bool {
+		return fmt.Sprintf("%t", o)
+	} else if k == reflect.Array || k == reflect.Slice || k == reflect.Map || k == reflect.Struct {
+		return fmt.Sprintf("%v", o)
 	} else {
 		return ""
 	}

--- a/cast.go
+++ b/cast.go
@@ -25,17 +25,21 @@ func Kind(o interface{}) reflect.Kind {
 }
 
 func ToString(o interface{}) string {
+	if IsPointer(o) {
+		return ""
+	}
+
 	v := Value(o)
 	k := v.Kind()
-	t := v.Type()
+
 	if k == reflect.Interface && v.IsNil() {
 		return ""
 	} else if k == reflect.String {
-		if t.Name() == "string" {
-			return o.(string)
-		} else {
-			return Sprintf("%s", o)
+		if val, ok := o.(string); ok {
+			return val
 		}
+
+		return Sprintf("%s", o)
 	} else if k == reflect.Int || k == reflect.Int8 || k == reflect.Int16 || k == reflect.Int32 || k == reflect.Int64 {
 		return fmt.Sprintf("%d", o)
 	} else if k == reflect.Uint || k == reflect.Uint8 || k == reflect.Uint16 || k == reflect.Uint32 || k == reflect.Uint64 {
@@ -144,6 +148,10 @@ func String2Date(dateString string, dateFormat string) time.Time {
 }
 
 func ToInt(o interface{}, rounding string) int {
+	if IsPointer(o) {
+		return 0
+	}
+
 	var ret int
 	k := Kind(o)
 	v := Value(o)
@@ -173,6 +181,10 @@ func ToInt(o interface{}, rounding string) int {
 }
 
 func ToFloat32(o interface{}, decimalPoint int, rounding string) float32 {
+	if IsPointer(o) {
+		return float32(0)
+	}
+
 	var f float64
 
 	k := Kind(o)
@@ -180,33 +192,41 @@ func ToFloat32(o interface{}, decimalPoint int, rounding string) float32 {
 
 	if k == reflect.String {
 		f = ToFloat64(v.String(), 0, rounding)
-	} else if k == reflect.Int || k == reflect.Int8 ||
-		k == reflect.Int16 || k == reflect.Int32 || k == reflect.Int64 {
+	} else if k == reflect.Int || k == reflect.Int8 || k == reflect.Int16 || k == reflect.Int32 || k == reflect.Int64 {
 		f = ToFloat64(v.Int(), decimalPoint, rounding)
+	} else if k == reflect.Uint || k == reflect.Uint8 || k == reflect.Uint16 || k == reflect.Uint32 || k == reflect.Uint64 {
+		f = ToFloat64(v.Uint(), decimalPoint, rounding)
 	} else if k == reflect.Float32 || k == reflect.Float64 {
 		f = ToFloat64(v.Float(), decimalPoint, rounding)
+	}
+
+	if math.IsNaN(f) || math.IsInf(f, 0) {
+		f = 0
 	}
 
 	return float32(f)
 }
 
 func ToFloat64(o interface{}, decimalPoint int, rounding string) float64 {
+	if IsPointer(o) {
+		return float64(0)
+	}
+
 	var f float64
 	var e error
 
 	k := Kind(o)
 	v := Value(o)
 
-	//Println("ToFloat Value: ", k.String())
 	if k == reflect.String {
 		f, e = strconv.ParseFloat(v.String(), 64)
 		if e != nil {
-			//Printf("Unable to convert to float %s\n", v.String())
 			return 0
 		}
-	} else if k == reflect.Int || k == reflect.Int8 ||
-		k == reflect.Int16 || k == reflect.Int32 || k == reflect.Int64 {
+	} else if k == reflect.Int || k == reflect.Int8 || k == reflect.Int16 || k == reflect.Int32 || k == reflect.Int64 {
 		f = float64(v.Int())
+	} else if k == reflect.Uint || k == reflect.Uint8 || k == reflect.Uint16 || k == reflect.Uint32 || k == reflect.Uint64 {
+		f = float64(v.Uint())
 	} else if k == reflect.Float32 || k == reflect.Float64 {
 		f = float64(v.Float())
 	}
@@ -273,5 +293,5 @@ func ToDate(o interface{}, formatDate string) time.Time {
 }
 
 func ToDuration(o interface{}) time.Duration {
-	return (1 * time.Second)
+	return time.Duration(ToInt(o, RoundingAuto)) * time.Second
 }

--- a/cast_test.go
+++ b/cast_test.go
@@ -173,15 +173,45 @@ func TestRoundingUp64(t *testing.T) {
 	t.Skip("covered by TestToFloat64()")
 }
 
-func TestToDate(t *testing.T) {
+func TestToDateUsingUnixData(t *testing.T) {
 	time1, err := time.Parse(time.RFC3339, "2012-11-01T22:08:41+00:00")
 	if err != nil {
 		t.Fatal(err.Error())
 	}
 
-	time2 := ToDate(time1.UnixNano(), "")
+	time2 := ToDate(time1.Unix(), "")
+	assert.Equal(t,
+		time1.UTC().Format("2006-01-02 15:04:05"),
+		time2.UTC().Format("2006-01-02 15:04:05"),
+	)
+}
 
-	assert.Equal(t, time1.Format("2012-11-01 22:08:41"), time2.Format("2012-11-01 22:08:41"))
+func TestToDateUsingDateString(t *testing.T) {
+	dateString := "2012-11-01T22:08:41+00:00"
+	time1, err := time.Parse(time.RFC3339, dateString)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	time2 := ToDate(dateString, time.RFC3339)
+	assert.Equal(t,
+		time1.UTC().Format("2006-01-02 15:04:05"),
+		time2.UTC().Format("2006-01-02 15:04:05"),
+	)
+}
+
+func TestToDateUsingTime(t *testing.T) {
+	dateString := "2012-11-01T22:08:41+00:00"
+	time1, err := time.Parse(time.RFC3339, dateString)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	time2 := ToDate(time1, time.RFC3339)
+	assert.Equal(t,
+		time1.UTC().Format("2006-01-02 15:04:05"),
+		time2.UTC().Format("2006-01-02 15:04:05"),
+	)
 }
 
 func TestToDuration(t *testing.T) {

--- a/cast_test.go
+++ b/cast_test.go
@@ -1,0 +1,49 @@
+package toolkit
+
+import (
+	"github.com/stretchr/testify/assert"
+	"reflect"
+	"testing"
+)
+
+func TestValue(t *testing.T) {
+	data := "hello"
+	assert.Equal(t,
+		reflect.Indirect(reflect.ValueOf(data)).Interface(),
+		Value(data).Interface(),
+	)
+}
+
+func TestKind(t *testing.T) {
+	data := "hello"
+	assert.Equal(t,
+		reflect.Indirect(reflect.ValueOf(data)).Kind(),
+		Value(data).Kind(),
+	)
+}
+
+func TestToString(t *testing.T) {
+	res1 := ToString("hello")
+	assert.Equal(t, "hello", res1)
+
+	res2 := ToString(12)
+	assert.Equal(t, "12", res2)
+
+	res3 := ToString(float64(12.123))
+	assert.Contains(t, res3, "12.123")
+
+	res4 := ToString(true)
+	assert.Equal(t, "true", res4)
+
+	res5 := ToString([]string{"a", "b", "c", "d"})
+	assert.Equal(t, "[a b c d]", res5)
+
+	res6 := ToString(interface{}(int64(32)))
+	assert.Equal(t, "32", res6)
+
+	res7 := ToString(uint(12))
+	assert.Equal(t, "12", res7)
+
+	res8 := ToString(map[string]int{"a": 1, "b": 2})
+	assert.True(t, res8 == "map[b:2 a:1]" || res8 == "map[a:1 b:2]")
+}

--- a/cast_test.go
+++ b/cast_test.go
@@ -174,7 +174,14 @@ func TestRoundingUp64(t *testing.T) {
 }
 
 func TestToDate(t *testing.T) {
-	t.Skip("in progress")
+	time1, err := time.Parse(time.RFC3339, "2012-11-01T22:08:41+00:00")
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+
+	time2 := ToDate(time1.UnixNano(), "")
+
+	assert.Equal(t, time1.Format("2012-11-01 22:08:41"), time2.Format("2012-11-01 22:08:41"))
 }
 
 func TestToDuration(t *testing.T) {

--- a/cast_test.go
+++ b/cast_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"reflect"
 	"testing"
+	"time"
 )
 
 func TestValue(t *testing.T) {
@@ -46,4 +47,140 @@ func TestToString(t *testing.T) {
 
 	res8 := ToString(map[string]int{"a": 1, "b": 2})
 	assert.True(t, res8 == "map[b:2 a:1]" || res8 == "map[a:1 b:2]")
+
+	data9 := "hello"
+	res9 := ToString(&data9)
+	assert.Empty(t, res9)
+
+	var data10 *int
+	res10 := ToString(data10)
+	assert.Empty(t, res10)
+
+	var data11 interface{}
+	res11 := ToString(data11)
+	assert.Empty(t, res11)
+}
+
+func TestSetDefaultDateFormat(t *testing.T) {
+	t.Skip("in progress")
+}
+
+func TestDefaultDateFormat(t *testing.T) {
+	t.Skip("in progress")
+}
+
+func TestDate2String(t *testing.T) {
+	t.Skip("in progress")
+}
+
+func TestString2Date(t *testing.T) {
+	t.Skip("in progress")
+}
+
+func TestToInt(t *testing.T) {
+	res1 := ToInt(12, RoundingAuto)
+	assert.Equal(t, 12, res1)
+
+	res2 := ToInt("12", RoundingAuto)
+	assert.Equal(t, 12, res2)
+
+	res3 := ToInt(float64(12.00123), RoundingAuto)
+	assert.Equal(t, 12, res3)
+
+	res4 := ToInt(float64(12.999), RoundingAuto)
+	assert.Equal(t, 13, res4)
+
+	res5 := ToInt(float64(12.999), RoundingDown)
+	assert.Equal(t, 12, res5)
+
+	res6 := ToInt(float64(12.00123), RoundingUp)
+	assert.Equal(t, 13, res6)
+
+	res7 := ToInt(uint(12), "")
+	assert.Equal(t, 12, res7)
+
+	data8 := 12
+	res8 := ToInt(&data8, RoundingAuto)
+	assert.Empty(t, res8)
+
+	res9 := ToInt("12.0012345", RoundingAuto)
+	assert.Equal(t, 12, res9)
+}
+
+func TestToFloat32(t *testing.T) {
+	res1 := ToFloat32(12, 5, RoundingAuto)
+	assert.Equal(t, float32(12), res1)
+
+	res2 := ToFloat32("12", 5, RoundingAuto)
+	assert.Equal(t, float32(12), res2)
+
+	res3 := ToFloat32(12.0021, 5, RoundingUp)
+	assert.Equal(t, float32(12.0021), res3)
+
+	res4 := ToFloat32(12.0021234567, 5, RoundingAuto)
+	assert.Equal(t, float32(12.00212), res4)
+
+	res5 := ToFloat32(12.0021234567, 6, RoundingDown)
+	assert.Equal(t, float32(12.002123), res5)
+
+	res6 := ToFloat32(12.0021234567, 7, RoundingDown)
+	assert.Equal(t, float32(12.0021234), res6)
+
+	data7 := 12
+	res7 := ToFloat32(&data7, 5, RoundingAuto)
+	assert.Empty(t, res7)
+
+	res8 := ToFloat32(uint(12), 7, RoundingDown)
+	assert.Equal(t, float32(12), res8)
+}
+
+func TestToFloat64(t *testing.T) {
+	res1 := ToFloat64(12, 5, RoundingAuto)
+	assert.Equal(t, float64(12), res1)
+
+	res2 := ToFloat64("12", 5, RoundingAuto)
+	assert.Equal(t, float64(12), res2)
+
+	res3 := ToFloat64(12.0021, 5, RoundingUp)
+	assert.Equal(t, float64(12.0021), res3)
+
+	res4 := ToFloat64(12.0021234567, 5, RoundingAuto)
+	assert.Equal(t, float64(12.00212), res4)
+
+	res5 := ToFloat64(12.0021234567, 6, RoundingDown)
+	assert.Equal(t, float64(12.002123), res5)
+
+	res6 := ToFloat64(12.0021234567, 7, RoundingDown)
+	assert.Equal(t, float64(12.0021234), res6)
+
+	data7 := 12
+	res7 := ToFloat64(&data7, 5, RoundingAuto)
+	assert.Empty(t, res7)
+
+	res8 := ToFloat64(uint(12), 7, RoundingDown)
+	assert.Equal(t, float64(12), res8)
+}
+
+func TestRoundingAuto64(t *testing.T) {
+	t.Skip("covered by TestToFloat64()")
+}
+
+func TestRoundingDown64(t *testing.T) {
+	t.Skip("covered by TestToFloat64()")
+}
+
+func TestRoundingUp64(t *testing.T) {
+	t.Skip("covered by TestToFloat64()")
+}
+
+func TestToDate(t *testing.T) {
+	t.Skip("in progress")
+}
+
+func TestToDuration(t *testing.T) {
+	res1 := ToDuration("12")
+	assert.Equal(t, time.Duration(12)*time.Second, res1)
+
+	res2 := ToDuration(12)
+	assert.Equal(t, time.Duration(12)*time.Second, res2)
 }

--- a/m.go
+++ b/m.go
@@ -123,7 +123,7 @@ func ToM(data interface{}) (M, error) {
 	}
 
 	// If the data element is not map or struct then return error
-	return nil, Errorf("Expecting struct or map object but got", rv.Kind())
+	return nil, Errorf("Expecting struct or map object but got %s", rv.Kind())
 }
 
 func (m M) ToBytes(encodertype string, others ...interface{}) []byte {

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,2 @@
 clear && printf '\e[3J'
-GOCACHE=off go test -v ./
+GOCACHE=off go test -cover -v ./

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,2 @@
+clear && printf '\e[3J'
+GOCACHE=off go test -v ./

--- a/test.sh
+++ b/test.sh
@@ -1,2 +1,0 @@
-clear && printf '\e[3J'
-GOCACHE=off go test -cover -v ./

--- a/test_coverage.sh
+++ b/test_coverage.sh
@@ -1,0 +1,4 @@
+clear && printf '\e[3J'
+GOCACHE=off go test -cover -coverprofile cover.out -v ./
+go tool cover -html=cover.out -o cover.html
+open cover.html

--- a/test_coverage.sh
+++ b/test_coverage.sh
@@ -1,4 +1,0 @@
-clear && printf '\e[3J'
-GOCACHE=off go test -cover -coverprofile cover.out -v ./
-go tool cover -html=cover.out -o cover.html
-open cover.html


### PR DESCRIPTION
This PR contains several changes, mostly about adding unit test to cover functionality on files `bytes.go` and `cast.go`. Also there are few small bug fixes.

Additions:
- Add readme file with test coverage badge
- Add `bytes_test.go`
- Add `cast_test.go`
- Add makefile
  - Use `make test` to perform unit test
  - Use `make test+coverage` to perform coverage test

Changes:
- fix bug syntax error on [m.go:126](https://github.com/eaciit/toolkit/blob/master/m.go#L126) after recent changes on `toolkit.ToM`.
- On `toolkit.ToString`, perform pointer checking. Also add support for these type of data to be converted to string: uint, bool, array, slice, map, struct.
- On `toolkit.ToFloat32` and `toolkit.ToFloat64`, add support for uint data type.
- Fix `toolkit.ToDuration`, previously it was doing nothing.
