### PR TITLE
Use Default Case instead of forced lowercase in ToMTag

### DIFF
--- a/m.go
+++ b/m.go
@@ -86,7 +86,7 @@ func ToM(data interface{}) (M, error) {
 }
 
 func ToMTag(data interface{}, tagName string) (M, error) {
-	return tomTagName(data, CaseLower, tagName)
+	return tomTagName(data, DefaultCase, tagName)
 }
 
 var _tagName string

--- a/m.go
+++ b/m.go
@@ -119,7 +119,7 @@ func tomTagName(data interface{}, namePattern string, tagName string) (M, error)
 			f := rv.Type().Field(i)
 			fieldName := f.Name
 			if f.Tag.Get(tagName) != "" {
-				fieldName = f.Tag.Get(tagName)
+				fieldName = strings.Split(f.Tag.Get(tagName), ",")[0]
 			}
 			if fieldName == "-" {
 				continue

--- a/m.go
+++ b/m.go
@@ -135,13 +135,16 @@ func tomTagName(data interface{}, namePattern string, tagName string) (M, error)
 
 			// If the type is struct but not time.Time or is a map
 			if (f.Type.Kind() == reflect.Struct && f.Type != reflect.TypeOf(time.Time{})) || f.Type.Kind() == reflect.Map {
+				
 				// Then we need to call this function again to fetch the sub value
-				subRes, err := tom(rv.Field(i).Interface(), namePattern)
-				if err != nil {
-					return nil, err
-				}
+				if rv.Field(i).CanInterface() {
+					subRes, err := tom(rv.Field(i).Interface(), namePattern)
+					if err != nil {
+						return nil, err
+					}
 
-				res[fieldName] = subRes
+					res[fieldName] = subRes
+				}
 
 				// Skip the rest
 				continue


### PR DESCRIPTION
- Use Default Case instead of forced lowercase in ToMTag
- Take first component of tagName useful incase of somthing line `bson:"_id, omitempty"`